### PR TITLE
MaterialDialog: Adjust default styling and add more customization

### DIFF
--- a/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/DatePicker.kt
+++ b/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/DatePicker.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight.Companion.W400
@@ -79,7 +80,11 @@ fun MaterialDialog.datepicker(
 ) {
     val datePickerState = remember { DatePickerState(initialDate) }
 
-    DatePickerImpl(state = datePickerState, yearRange = yearRange)
+    DatePickerImpl(
+        state = datePickerState,
+        yearRange = yearRange,
+        backgroundColor = dialogBackgroundColor ?: MaterialTheme.colors.surface
+    )
 
     val index = remember {
         val callbackIndex = callbackCounter.getAndIncrement()
@@ -102,7 +107,8 @@ fun MaterialDialog.datepicker(
 internal fun DatePickerImpl(
     modifier: Modifier = Modifier,
     state: DatePickerState,
-    yearRange: IntRange
+    yearRange: IntRange,
+    backgroundColor: Color
 ) {
     /* Height doesn't include datepicker button height */
     Column(modifier.size(328.dp, 460.dp)) {
@@ -123,7 +129,7 @@ internal fun DatePickerImpl(
                     enter = slideInVertically({ -it }),
                     exit = slideOutVertically({ -it })
                 ) {
-                    YearPicker(yearRange, viewDate, yearPickerShowing)
+                    YearPicker(yearRange, viewDate, yearPickerShowing, backgroundColor)
                 }
 
                 CalendarView(viewDate, state)
@@ -136,14 +142,15 @@ internal fun DatePickerImpl(
 private fun ViewPagerScope.YearPicker(
     yearRange: IntRange,
     viewDate: LocalDate,
-    yearPickerShowing: MutableState<Boolean>
+    yearPickerShowing: MutableState<Boolean>,
+    backgroundColor: Color
 ) {
     val state = rememberLazyListState((viewDate.year - yearRange.first) / 3)
     val coroutineScope = rememberCoroutineScope()
 
     LazyColumn(
         modifier = Modifier
-            .background(MaterialTheme.colors.surface)
+            .background(backgroundColor)
             .padding(start = 24.dp, end = 24.dp),
         state = state
     ) {
@@ -175,7 +182,7 @@ private fun ViewPagerScope.YearPicker(
 @Composable
 private fun YearPickerItem(year: Int, selected: Boolean, onClick: () -> Unit) {
     val backgroundColor =
-        if (selected) MaterialTheme.colors.primary else MaterialTheme.colors.surface
+        if (selected) MaterialTheme.colors.primary else Color.Transparent
     val textColor = if (selected) MaterialTheme.colors.onPrimary else MaterialTheme.colors.onSurface
 
     Box(Modifier.size(88.dp, 52.dp), contentAlignment = Alignment.Center) {
@@ -211,7 +218,6 @@ private fun ViewPagerScope.CalendarViewHeader(
 
     Box(
         Modifier
-            .background(MaterialTheme.colors.background)
             .padding(top = 16.dp, bottom = 16.dp, start = 24.dp, end = 24.dp)
             .height(24.dp)
             .fillMaxWidth()
@@ -314,7 +320,7 @@ private fun CalendarView(viewDate: LocalDate, datePickerData: DatePickerState) {
 private fun DateSelectionBox(date: Int, selected: Boolean, onClick: () -> Unit) {
     val colors = MaterialTheme.colors
     val backgroundColor = remember(selected) {
-        if (selected) colors.primary else colors.surface
+        if (selected) colors.primary else Color.Transparent
     }
     val textColor = remember(selected) {
         if (selected) colors.onPrimary else colors.onSurface

--- a/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/DateTimePicker.kt
+++ b/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/DateTimePicker.kt
@@ -3,6 +3,7 @@ package com.vanpra.composematerialdialogs.datetime
 import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.mutableStateOf
@@ -45,6 +46,9 @@ fun MaterialDialog.datetimepicker(
     val scrollPos = remember { Animatable(0f) }
     val scrollTo = remember { mutableStateOf(0f) }
 
+    val isDateScreen = remember(scrollPos.value, scrollTo.value) { scrollPos.value < scrollTo.value / 2 }
+    useElevationOverlay = isDateScreen
+
     BoxWithConstraints {
         Column {
             SideEffect {
@@ -54,7 +58,11 @@ fun MaterialDialog.datetimepicker(
 
             Layout(
                 content = {
-                    DatePickerImpl(state = datePickerState, yearRange = yearRange)
+                    DatePickerImpl(
+                        state = datePickerState,
+                        yearRange = yearRange,
+                        backgroundColor = dialogBackgroundColor ?: MaterialTheme.colors.surface
+                    )
                     TimePickerImpl(state = timePickerState) {
                         coroutineScope.launch { scrollPos.animateTo(0f) }
                     }
@@ -76,8 +84,6 @@ fun MaterialDialog.datetimepicker(
     }
 
     buttons {
-        val isDateScreen = remember(scrollPos.value) { scrollPos.value == 0f }
-
         positiveButton(
             text = if (isDateScreen) {
                 "Next"

--- a/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/TimePicker.kt
+++ b/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/TimePicker.kt
@@ -262,6 +262,8 @@ fun MaterialDialog.timepicker(
     waitForPositiveButton: Boolean = true,
     onComplete: (LocalTime) -> Unit = {}
 ) {
+    useElevationOverlay = false
+
     val timePickerState = remember { TimePickerState(selectedTime = initialTime, colors = colors) }
 
     val index = remember {


### PR DESCRIPTION
I know this is different from the library reference styling, but I personally think this is a good addition since in my use case it makes it possible to get uniform styling with other dialogs created without this library.

I'm open to discussion for the implementation if it doesn't up to your liking.