### PR TITLE
Add 24h clock support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,6 +24,7 @@ android {
     }
 
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
@@ -55,4 +56,5 @@ dependencies {
     implementation(Dependencies.material)
 
     implementation(kotlin("stdlib-jdk8"))
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:1.1.5")
 }

--- a/app/src/main/java/com/vanpra/composematerialdialogdemos/demos/DateTimeDialog.kt
+++ b/app/src/main/java/com/vanpra/composematerialdialogdemos/demos/DateTimeDialog.kt
@@ -10,6 +10,7 @@ import com.vanpra.composematerialdialogs.datetime.TimePickerDefaults
 import com.vanpra.composematerialdialogs.datetime.datepicker
 import com.vanpra.composematerialdialogs.datetime.datetimepicker
 import com.vanpra.composematerialdialogs.datetime.timepicker
+import java.time.LocalTime
 
 /**
  * @brief Date and Time Picker Demos
@@ -35,7 +36,9 @@ fun DateTimeDialogDemo() {
     }
 
     DialogAndShowButton(buttonText = "Time Picker Dialog") {
-        timepicker(colors = colors) {
+        timepicker(colors = colors,
+            minimumTime = LocalTime.of(9, 35),
+            maximumTime = LocalTime.of(11, 13)) {
             println(it.toString())
         }
 

--- a/app/src/main/java/com/vanpra/composematerialdialogdemos/demos/DateTimeDialog.kt
+++ b/app/src/main/java/com/vanpra/composematerialdialogdemos/demos/DateTimeDialog.kt
@@ -1,9 +1,11 @@
 package com.vanpra.composematerialdialogdemos.demos
 
+import android.widget.Toast
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import com.vanpra.composematerialdialogdemos.DialogAndShowButton
 import com.vanpra.composematerialdialogs.datetime.TimePickerColors
 import com.vanpra.composematerialdialogs.datetime.TimePickerDefaults
@@ -35,12 +37,28 @@ fun DateTimeDialogDemo() {
         )
     }
 
+    val context = LocalContext.current
+
     DialogAndShowButton(buttonText = "Time Picker Dialog") {
+        timepicker(colors = colors) {
+            println(it.toString())
+            Toast.makeText(context, it.toString(), Toast.LENGTH_LONG).show()
+        }
+
+        buttons {
+            positiveButton("Ok")
+            negativeButton("Cancel")
+        }
+    }
+
+    DialogAndShowButton(buttonText = "Time Picker Dialog With Min/Max") {
         timepicker(colors = colors,
             minimumTime = LocalTime.of(9, 35),
-            maximumTime = LocalTime.of(11, 13)) {
+            maximumTime = LocalTime.of(21, 13)) {
             println(it.toString())
+            Toast.makeText(context, it.toString(), Toast.LENGTH_LONG).show()
         }
+
 
         buttons {
             positiveButton("Ok")

--- a/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/DateTimePicker.kt
+++ b/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/DateTimePicker.kt
@@ -45,6 +45,9 @@ fun MaterialDialog.datetimepicker(
         TimePickerState(selectedTime = initialDateTime.toLocalTime(), colors = timePickerColors, minimumTime = minimumTime, maximumTime = maximumTime)
     }
 
+    timePickerState.minimumTime = SimpleLocalTime.fromLocalTime(minimumTime)
+    timePickerState.maximumTime = SimpleLocalTime.fromLocalTime(maximumTime)
+
     val scrollPos = remember { Animatable(0f) }
     val scrollTo = remember { mutableStateOf(0f) }
 

--- a/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/DateTimePicker.kt
+++ b/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/DateTimePicker.kt
@@ -3,11 +3,7 @@ package com.vanpra.composematerialdialogs.datetime
 import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.*
 import androidx.compose.ui.layout.Layout
 import com.vanpra.composematerialdialogs.MaterialDialog
 import kotlinx.coroutines.launch
@@ -45,8 +41,14 @@ fun MaterialDialog.datetimepicker(
         TimePickerState(selectedTime = initialDateTime.toLocalTime(), colors = timePickerColors, minimumTime = minimumTime, maximumTime = maximumTime)
     }
 
-    timePickerState.minimumTime = SimpleLocalTime.fromLocalTime(minimumTime)
-    timePickerState.maximumTime = SimpleLocalTime.fromLocalTime(maximumTime)
+    DisposableEffect(minimumTime) {
+        timePickerState.minimumTime = SimpleLocalTime.fromLocalTime(minimumTime)
+        onDispose {  }
+    }
+    DisposableEffect(maximumTime) {
+        timePickerState.maximumTime = SimpleLocalTime.fromLocalTime(maximumTime)
+        onDispose {  }
+    }
 
     val scrollPos = remember { Animatable(0f) }
     val scrollTo = remember { mutableStateOf(0f) }

--- a/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/DateTimePicker.kt
+++ b/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/DateTimePicker.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.layout.Layout
 import com.vanpra.composematerialdialogs.MaterialDialog
 import kotlinx.coroutines.launch
 import java.time.LocalDateTime
+import java.time.LocalTime
 
 /**
  * @brief A combined date and time picker dialog
@@ -30,6 +31,8 @@ fun MaterialDialog.datetimepicker(
     initialDateTime: LocalDateTime = LocalDateTime.now(),
     timePickerColors: TimePickerColors = TimePickerDefaults.colors(),
     yearRange: IntRange = IntRange(1900, 2100),
+    minimumTime: LocalTime = LocalTime.MIN,
+    maximumTime: LocalTime = LocalTime.MAX,
     positiveButtonText: String = "Ok",
     negativeButtonText: String = "Cancel",
     onCancel: () -> Unit = {},
@@ -39,7 +42,7 @@ fun MaterialDialog.datetimepicker(
 
     val datePickerState = remember { DatePickerState(initialDateTime.toLocalDate()) }
     val timePickerState = remember {
-        TimePickerState(selectedTime = initialDateTime.toLocalTime(), colors = timePickerColors)
+        TimePickerState(selectedTime = initialDateTime.toLocalTime(), colors = timePickerColors, minimumTime = minimumTime, maximumTime = maximumTime)
     }
 
     val scrollPos = remember { Animatable(0f) }

--- a/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/DateTimePicker.kt
+++ b/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/DateTimePicker.kt
@@ -3,7 +3,12 @@ package com.vanpra.composematerialdialogs.datetime
 import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.layout.Layout
 import com.vanpra.composematerialdialogs.MaterialDialog
 import kotlinx.coroutines.launch

--- a/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/TimePicker.kt
+++ b/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/TimePicker.kt
@@ -30,6 +30,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.SliderDefaults
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
+import androidx.compose.material.ContentAlpha
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
@@ -65,6 +66,7 @@ import kotlin.math.abs
 import kotlin.math.cos
 import kotlin.math.pow
 import kotlin.math.sin
+import kotlin.math.roundToInt
 
 /* Offset of the clock line and selected circle */
 private data class SelectedOffset(
@@ -73,7 +75,7 @@ private data class SelectedOffset(
 )
 
 /* Data class for 12-hour time format */
-internal class SimpleLocalTime(hour: Int, minute: Int, isAM: Boolean) {
+internal class SimpleLocalTime(hour: Int, minute: Int, isAM: Boolean) : Comparable<SimpleLocalTime> {
     var hour by mutableStateOf(hour)
     var minute by mutableStateOf(minute)
     var isAM by mutableStateOf(isAM)
@@ -105,6 +107,10 @@ internal class SimpleLocalTime(hour: Int, minute: Int, isAM: Boolean) {
             }
             return SimpleLocalTime(hour, time.minute, isAM)
         }
+    }
+
+    override fun compareTo(other: SimpleLocalTime): Int {
+        return toLocalTime().compareTo(other.toLocalTime())
     }
 }
 
@@ -231,18 +237,71 @@ internal class TimePickerState(
     selectedTime: SimpleLocalTime,
     currentScreen: ClockScreen = ClockScreen.Hour,
     clockInput: Boolean = true,
-    val colors: TimePickerColors
+    val colors: TimePickerColors,
+    val minimumTime: SimpleLocalTime,
+    val maximumTime: SimpleLocalTime
 ) {
     constructor(
         selectedTime: LocalTime,
         currentScreen: ClockScreen = ClockScreen.Hour,
         clockInput: Boolean = true,
-        colors: TimePickerColors
-    ) : this(SimpleLocalTime.fromLocalTime(selectedTime), currentScreen, clockInput, colors)
+        colors: TimePickerColors,
+        minimumTime: LocalTime,
+        maximumTime: LocalTime,
+    ) : this(
+        SimpleLocalTime.fromLocalTime(selectedTime),
+        currentScreen,
+        clockInput,
+        colors,
+        SimpleLocalTime.fromLocalTime(minimumTime),
+        SimpleLocalTime.fromLocalTime(maximumTime)
+    )
 
     var selectedTime by mutableStateOf(selectedTime)
     var currentScreen by mutableStateOf(currentScreen)
     var clockInput by mutableStateOf(clockInput)
+
+    fun minimumHour(isAM: Boolean): Int {
+        return when {
+            isAM == minimumTime.isAM -> minimumTime.hour
+            isAM -> 13
+            else -> 0
+        }
+    }
+
+    fun maximumHour(isAM: Boolean): Int {
+        return when {
+            isAM == maximumTime.isAM -> maximumTime.hour
+            isAM -> 12
+            else -> 0
+        }
+    }
+
+    fun minimumMinute(isAM: Boolean, hour: Int): Int {
+        return when {
+            isAM == minimumTime.isAM ->
+                if (minimumTime.hour == hour) {
+                    minimumTime.minute
+                } else {
+                    0
+                }
+            isAM -> 61
+            else -> 0
+        }
+    }
+
+    fun maximumMinute(isAM: Boolean, hour: Int): Int {
+        return when {
+            isAM == maximumTime.isAM ->
+                if (maximumTime.hour == hour) {
+                    maximumTime.minute
+                } else {
+                    60
+                }
+            isAM -> 60
+            else -> 0
+        }
+    }
 }
 
 /**
@@ -260,9 +319,18 @@ fun MaterialDialog.timepicker(
     initialTime: LocalTime = LocalTime.now(),
     colors: TimePickerColors = TimePickerDefaults.colors(),
     waitForPositiveButton: Boolean = true,
+    minimumTime: LocalTime = LocalTime.MIN,
+    maximumTime: LocalTime = LocalTime.MAX,
     onComplete: (LocalTime) -> Unit = {}
 ) {
-    val timePickerState = remember { TimePickerState(selectedTime = initialTime, colors = colors) }
+    val timePickerState = remember {
+        TimePickerState(
+            selectedTime = initialTime,
+            colors = colors,
+            minimumTime = minimumTime,
+            maximumTime = maximumTime
+        )
+    }
 
     val index = remember {
         val callbackIndex = callbackCounter.getAndIncrement()
@@ -289,6 +357,12 @@ internal fun TimePickerImpl(
     state: TimePickerState,
     onBack: (() -> Unit)? = null
 ) {
+    if (state.selectedTime < state.minimumTime) {
+        state.selectedTime = SimpleLocalTime.fromLocalTime(state.minimumTime.toLocalTime())
+    }
+    if (state.selectedTime > state.maximumTime) {
+        state.selectedTime = SimpleLocalTime.fromLocalTime(state.maximumTime.toLocalTime())
+    }
     Column(modifier.padding(start = 24.dp, end = 24.dp)) {
         TimePickerTitle(onBack)
         TimeLayout(state)
@@ -296,23 +370,42 @@ internal fun TimePickerImpl(
         Spacer(modifier = Modifier.height(36.dp))
         Crossfade(state.currentScreen) {
             when (it) {
-                ClockScreen.Hour -> ClockLayout(
-                    anchorPoints = 12,
-                    label = { index -> if (index == 0) "12" else index.toString() },
-                    onAnchorChange = { hours -> state.selectedTime.hour = hours },
-                    startAnchor = if (state.selectedTime.hour == 12) 0 else state.selectedTime.hour,
-                    onLift = { state.currentScreen = ClockScreen.Minute },
-                    colors = state.colors
-                )
-
-                ClockScreen.Minute -> ClockLayout(
-                    anchorPoints = 60,
-                    label = { index -> index.toString().padStart(2, '0') },
-                    onAnchorChange = { mins -> state.selectedTime.minute = mins },
-                    startAnchor = state.selectedTime.minute,
-                    isNamedAnchor = { anchor -> anchor % 5 == 0 },
-                    colors = state.colors
-                )
+                ClockScreen.Hour -> {
+                    val isEnabled: (Int) -> Boolean = remember(state.selectedTime.isAM) {
+                        { index ->
+                            index in state.minimumHour(state.selectedTime.isAM)..
+                                    state.maximumHour(state.selectedTime.isAM)
+                        }
+                    }
+                    ClockLayout(
+                        anchorPoints = 12,
+                        label = { index -> if (index == 0) "12" else index.toString() },
+                        onAnchorChange = { hours -> state.selectedTime.hour = hours },
+                        startAnchor = if (state.selectedTime.hour == 12) 0 else state.selectedTime.hour,
+                        onLift = { state.currentScreen = ClockScreen.Minute },
+                        colors = state.colors,
+                        isAnchorEnabled = isEnabled
+                    )
+                }
+                ClockScreen.Minute -> {
+                    val isEnabled: (Int) -> Boolean =
+                        remember(state.selectedTime.isAM, state.selectedTime.hour) {
+                            { index ->
+                                index in state.minimumMinute(state.selectedTime.isAM, state.selectedTime.hour)..
+                                        state.maximumMinute(state.selectedTime.isAM, state.selectedTime.hour
+                                )
+                            }
+                        }
+                    ClockLayout(
+                        anchorPoints = 60,
+                        label = { index -> index.toString().padStart(2, '0') },
+                        onAnchorChange = { mins -> state.selectedTime.minute = mins },
+                        startAnchor = state.selectedTime.minute,
+                        isNamedAnchor = { anchor -> anchor % 5 == 0 },
+                        colors = state.colors,
+                        isAnchorEnabled = isEnabled
+                    )
+                }
             }
         }
 
@@ -388,10 +481,11 @@ internal fun TimeLayout(state: TimePickerState) {
     )
     val bottomPeriodShape =
         MaterialTheme.shapes.medium.copy(topStart = CornerSize(0.dp), topEnd = CornerSize(0.dp))
-
+    val isAMEnabled = state.minimumHour(true) <= 12
+    val isPMEnabled = state.maximumHour(false) > 0
     Row(Modifier.height(80.dp)) {
         ClockLabel(
-            text = state.selectedTime.hour.toString(),
+            text = (if (state.selectedTime.hour == 0) 12 else state.selectedTime.hour).toString(),
             backgroundColor = state.colors.backgroundColor(state.currentScreen.isHour()).value,
             textColor = state.colors.textColor(state.currentScreen.isHour()).value,
             onClick = { state.currentScreen = ClockScreen.Hour }
@@ -422,10 +516,10 @@ internal fun TimeLayout(state: TimePickerState) {
                 modifier = Modifier.size(height = 40.dp, width = 52.dp)
                     .clip(topPeriodShape)
                     .background(state.colors.periodBackgroundColor(state.selectedTime.isAM).value)
-                    .clickable { state.selectedTime.isAM = true },
+                    .then(if (isAMEnabled) Modifier.clickable { state.selectedTime.isAM = true } else Modifier),
                 contentAlignment = Alignment.Center
             ) {
-                Text("AM", style = TextStyle(state.colors.textColor(state.selectedTime.isAM).value))
+                Text("AM", style = TextStyle(state.colors.textColor(state.selectedTime.isAM).value.copy(alpha = if (isAMEnabled) ContentAlpha.high else ContentAlpha.disabled)))
             }
 
             Spacer(Modifier.fillMaxWidth().height(1.dp).background(state.colors.border.brush))
@@ -434,12 +528,12 @@ internal fun TimeLayout(state: TimePickerState) {
                 modifier = Modifier.size(height = 40.dp, width = 52.dp)
                     .clip(bottomPeriodShape)
                     .background(state.colors.periodBackgroundColor(!state.selectedTime.isAM).value)
-                    .clickable { state.selectedTime.isAM = false },
+                    .then(if (isPMEnabled) Modifier.clickable { state.selectedTime.isAM = false } else Modifier),
                 contentAlignment = Alignment.Center
             ) {
                 Text(
                     "PM",
-                    style = TextStyle(state.colors.textColor(!state.selectedTime.isAM).value)
+                    style = TextStyle(state.colors.textColor(!state.selectedTime.isAM).value.copy(alpha = if (isPMEnabled) ContentAlpha.high else ContentAlpha.disabled))
                 )
             }
         }
@@ -453,6 +547,7 @@ private fun ClockLayout(
     label: (Int) -> String,
     startAnchor: Int,
     colors: TimePickerColors,
+    isAnchorEnabled: (Int) -> Boolean,
     onAnchorChange: (Int) -> Unit = {},
     onLift: () -> Unit = {}
 ) {
@@ -464,7 +559,8 @@ private fun ClockLayout(
     val namedAnchor = remember { mutableStateOf(isNamedAnchor(startAnchor)) }
     val selectedAnchor = remember { mutableStateOf(startAnchor) }
 
-    val anchors = remember {
+
+    val anchors = remember(anchorPoints) {
         val anchors = mutableListOf<SelectedOffset>()
         for (x in 0 until anchorPoints) {
             val angle = (2 * PI / anchorPoints) * (x - 15)
@@ -483,26 +579,37 @@ private fun ClockLayout(
 
     val anchoredOffset = remember { mutableStateOf(anchors[startAnchor]) }
 
-    fun updateAnchor(newOffset: Offset) {
-        val absDiff = anchors.map {
-            val diff = it.selectedOffset - newOffset + center.value
-            diff.x.pow(2) + diff.y.pow(2)
-        }
-        val minAnchor = absDiff.withIndex().minByOrNull { (_, f) -> f }?.index
-        if (anchoredOffset.value.selectedOffset != anchors[minAnchor!!].selectedOffset) {
-            onAnchorChange(label(minAnchor).toInt())
+    val updateAnchor : (Offset) -> Boolean = remember(anchors, isAnchorEnabled) {
+        { newOffset ->
+            val absDiff = anchors.mapIndexed { index, it ->
+                val diff = it.selectedOffset - newOffset + center.value
+                diff.x.pow(2) + diff.y.pow(2)
+            }
 
-            anchoredOffset.value = anchors[minAnchor]
-            namedAnchor.value = isNamedAnchor(minAnchor)
-            selectedAnchor.value = minAnchor
+            val minAnchor = absDiff.withIndex().minByOrNull { (_, f) -> f }?.index!!
+            if (isAnchorEnabled(minAnchor)) {
+                if (anchoredOffset.value.selectedOffset != anchors[minAnchor].selectedOffset) {
+                    onAnchorChange(label(minAnchor).toInt())
+
+                    anchoredOffset.value = anchors[minAnchor]
+                    namedAnchor.value = isNamedAnchor(minAnchor)
+                    selectedAnchor.value = minAnchor
+                }
+                true
+            } else {
+                false
+            }
         }
     }
 
+    val dragSuccess = remember { mutableStateOf(false) }
+
     val dragObserver: suspend PointerInputScope.() -> Unit = {
         detectDragGestures(
-            onDragEnd = { onLift() }
+            onDragStart = { dragSuccess.value = false },
+            onDragEnd = { if (dragSuccess.value) onLift() }
         ) { change, _ ->
-            updateAnchor(change.position)
+            dragSuccess.value = updateAnchor(change.position)
             change.consumePositionChange()
         }
     }
@@ -510,9 +617,9 @@ private fun ClockLayout(
     val tapObserver: suspend PointerInputScope.() -> Unit = {
         detectTapGestures(
             onPress = {
-                updateAnchor(it)
+                val updated = updateAnchor(it)
                 val success = tryAwaitRelease()
-                if (success) {
+                if (success && updated) {
                     onLift()
                 }
             }
@@ -535,6 +642,9 @@ private fun ClockLayout(
         val selectorColor = remember { colors.selectorColor() }
         val selectorTextColor = remember { colors.selectorTextColor().toArgb() }
         val clockSurfaceDiameter = remember(constraints.maxWidth) { constraints.maxWidth.toFloat() / 2f }
+
+        val enabledAlpha = ContentAlpha.high
+        val disabledAlpha = ContentAlpha.disabled
 
         Canvas(modifier = Modifier.fillMaxSize()) {
             drawCircle(clockBackgroundColor, radius = clockSurfaceDiameter, center = center.value)
@@ -566,12 +676,14 @@ private fun ClockLayout(
             drawIntoCanvas { canvas ->
                 for (x in 0 until 12) {
                     val angle = (2 * PI / 12) * (x - 15)
-                    val textOuter = label(x * anchorPoints / 12)
-                    val textColor = if (selectedAnchor.value == textOuter.toInt()) {
+                    val anchor = x * anchorPoints / 12
+                    val textOuter = label(anchor)
+                    val textColor = if (selectedAnchor.value == anchor) {
                         selectorTextColor
                     } else {
                         inactiveTextColor
                     }
+                    val alpha = (255f * (if (isAnchorEnabled(anchor)) enabledAlpha else disabledAlpha)).roundToInt()
 
                     drawText(
                         60f,
@@ -580,6 +692,7 @@ private fun ClockLayout(
                         angle.toFloat(),
                         canvas,
                         outerRadius,
+                        alpha = alpha,
                         color = textColor
                     )
                 }

--- a/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/TimePicker.kt
+++ b/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/TimePicker.kt
@@ -228,8 +228,8 @@ internal class TimePickerState(
     currentScreen: ClockScreen = ClockScreen.Hour,
     clockInput: Boolean = true,
     val colors: TimePickerColors,
-    val minimumTime: SimpleLocalTime,
-    val maximumTime: SimpleLocalTime
+    minimumTime: SimpleLocalTime,
+    maximumTime: SimpleLocalTime
 ) {
     constructor(
         selectedTime: LocalTime,
@@ -248,6 +248,8 @@ internal class TimePickerState(
     )
 
     var selectedTime by mutableStateOf(selectedTime)
+    var minimumTime by mutableStateOf(minimumTime)
+    var maximumTime by mutableStateOf(maximumTime)
     var currentScreen by mutableStateOf(currentScreen)
     var clockInput by mutableStateOf(clockInput)
 
@@ -321,6 +323,8 @@ fun MaterialDialog.timepicker(
             maximumTime = maximumTime
         )
     }
+    timePickerState.minimumTime = SimpleLocalTime.fromLocalTime(minimumTime)
+    timePickerState.maximumTime = SimpleLocalTime.fromLocalTime(maximumTime)
 
     val index = remember {
         val callbackIndex = callbackCounter.getAndIncrement()
@@ -361,7 +365,7 @@ internal fun TimePickerImpl(
         Crossfade(state.currentScreen) {
             when (it) {
                 ClockScreen.Hour -> {
-                    val isEnabled: (Int) -> Boolean = remember(state.selectedTime, state.selectedTime.isAM) {
+                    val isEnabled: (Int) -> Boolean = remember(state.minimumTime, state.maximumTime, state.selectedTime, state.selectedTime.isAM) {
                         { index ->
                             index in state.minimumHour(state.selectedTime.isAM)..
                                     state.maximumHour(state.selectedTime.isAM)
@@ -379,7 +383,7 @@ internal fun TimePickerImpl(
                 }
                 ClockScreen.Minute -> {
                     val isEnabled: (Int) -> Boolean =
-                        remember(state.selectedTime, state.selectedTime.isAM, state.selectedTime.hour) {
+                        remember(state.minimumTime, state.maximumTime, state.selectedTime, state.selectedTime.isAM, state.selectedTime.hour) {
                             { index ->
                                 index in state.minimumMinute(state.selectedTime.isAM, state.selectedTime.hour)..
                                         state.maximumMinute(state.selectedTime.isAM, state.selectedTime.hour

--- a/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/TimePicker.kt
+++ b/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/TimePicker.kt
@@ -502,9 +502,7 @@ internal fun TimeLayout(state: TimePickerState) {
         )
 
         Box(
-            Modifier
-                .width(24.dp)
-                .fillMaxHeight(),
+            Modifier.width(24.dp).fillMaxHeight(),
             contentAlignment = Alignment.Center
         ) {
             Text(
@@ -523,37 +521,25 @@ internal fun TimeLayout(state: TimePickerState) {
 
         Spacer(modifier = Modifier.width(12.dp))
 
-        Column(
-            Modifier
-                .fillMaxHeight()
-                .border(state.colors.border, MaterialTheme.shapes.medium)) {
+        Column(Modifier.fillMaxHeight().border(state.colors.border, MaterialTheme.shapes.medium)) {
             Box(
-                modifier = Modifier
-                    .size(height = 40.dp, width = 52.dp)
+                modifier = Modifier.size(height = 40.dp, width = 52.dp)
                     .clip(topPeriodShape)
                     .background(state.colors.periodBackgroundColor(state.selectedTime.isAM).value)
-                    .then(if (isAMEnabled) Modifier.clickable {
-                        state.selectedTime.isAM = true
-                    } else Modifier),
+                    .then(if (isAMEnabled) Modifier.clickable { state.selectedTime.isAM = true } else Modifier),
                 contentAlignment = Alignment.Center
             ) {
                 Text("AM", style = TextStyle(state.colors.textColor(state.selectedTime.isAM).value.copy(alpha = if (isAMEnabled) ContentAlpha.high else ContentAlpha.disabled)))
             }
 
-            Spacer(
-                Modifier
-                    .fillMaxWidth()
-                    .height(1.dp)
-                    .background(state.colors.border.brush))
+            Spacer(Modifier.fillMaxWidth().height(1.dp).background(state.colors.border.brush))
 
             Box(
                 modifier = Modifier
                     .size(height = 40.dp, width = 52.dp)
                     .clip(bottomPeriodShape)
                     .background(state.colors.periodBackgroundColor(!state.selectedTime.isAM).value)
-                    .then(if (isPMEnabled) Modifier.clickable {
-                        state.selectedTime.isAM = false
-                    } else Modifier),
+                    .then(if (isPMEnabled) Modifier.clickable { state.selectedTime.isAM = false } else Modifier),
                 contentAlignment = Alignment.Center
             ) {
                 Text(
@@ -652,9 +638,7 @@ private fun ClockLayout(
     }
 
     BoxWithConstraints(
-        Modifier
-            .padding(horizontal = 12.dp)
-            .size(256.dp)
+        Modifier.padding(horizontal = 12.dp).size(256.dp)
             .pointerInput(null, dragObserver)
             .pointerInput(null, tapObserver)
     ) {

--- a/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/TimePicker.kt
+++ b/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/TimePicker.kt
@@ -538,11 +538,11 @@ internal fun TimeLayout(state: TimePickerState) {
         MaterialTheme.shapes.medium.copy(topStart = CornerSize(0.dp), topEnd = CornerSize(0.dp))
     val isAMEnabled = remember(state.minimumTime) { state.minimumHour(true) <= 12 }
     val isPMEnabled = remember(state.maximumTime) { state.maximumHour(false) >= 0 }
-    val is24Hour = remember(state.is24Hour) { state.is24Hour }
+    val clockHour = remember(state.is24Hour, state.selectedTime, state.selectedTime.hour) {if (state.is24Hour) state.selectedTime.hour24.toString().padStart(2, '0') else (if (state.selectedTime.hour == 0) 12 else state.selectedTime.hour).toString()}
 
     Row(horizontalArrangement = Arrangement.Center, modifier = Modifier.height(80.dp).fillMaxWidth()) {
         ClockLabel(
-            text = if (is24Hour) state.selectedTime.hour24.toString().padStart(2, '0') else (if (state.selectedTime.hour == 0) 12 else state.selectedTime.hour).toString(),
+            text = clockHour,
             backgroundColor = state.colors.backgroundColor(state.currentScreen.isHour()).value,
             textColor = state.colors.textColor(state.currentScreen.isHour()).value,
             onClick = { state.currentScreen = ClockScreen.Hour }
@@ -565,7 +565,7 @@ internal fun TimeLayout(state: TimePickerState) {
         onClick = { state.currentScreen = ClockScreen.Minute }
 
         )
-        if (!is24Hour) {
+        if (!state.is24Hour) {
             Spacer(modifier = Modifier.width(12.dp))
 
             Column(Modifier.fillMaxHeight().border(state.colors.border, MaterialTheme.shapes.medium)) {


### PR DESCRIPTION
Add inner circle with hours 12-23, remove AM/PM selector, format hour label in 24h format. 
Enabled automatically based on context with ability to override.