### PR TITLE
"noSeconds()" extension now correctly creates a LocalTime of the hour/minute

### DIFF
--- a/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/util/Extensions.kt
+++ b/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/util/Extensions.kt
@@ -37,4 +37,4 @@ internal val LocalTime.simpleHour: Int
 internal fun LocalTime.toAM(): LocalTime = if (this.isAM) this else this.minusHours(12)
 internal fun LocalTime.toPM(): LocalTime = if (!this.isAM) this else this.plusHours(12)
 
-internal fun LocalTime.noSeconds(): LocalTime = LocalTime.of(this.hour, this.second)
+internal fun LocalTime.noSeconds(): LocalTime = LocalTime.of(this.hour, this.minute)


### PR DESCRIPTION
It used to create a LocalTime with hour and second