### PR TITLE
Updates 1.0.0-rc01, Fixes width error with 1.0.0-rc01

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,7 @@ allprojects {
                 "-Xopt-in=androidx.compose.material.ExperimentalMaterialApi",
                 "-Xopt-in=androidx.compose.animation.ExperimentalAnimationApi",
                 "-Xopt-in=androidx.compose.foundation.ExperimentalFoundationApi",
+                "-Xopt-in=androidx.compose.ui.ExperimentalComposeUiApi",
                 )
         }
     }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -30,7 +30,7 @@ object Dependencies {
         const val coreKtx = "androidx.core:core-ktx:1.6.0-rc01"
 
         object Compose {
-            const val version = "1.0.0-beta09"
+            const val version = "1.0.0-rc01"
 
             const val ui = "androidx.compose.ui:ui:$version"
             const val material = "androidx.compose.material:material:$version"

--- a/core/src/main/java/com/vanpra/composematerialdialogs/Utils.kt
+++ b/core/src/main/java/com/vanpra/composematerialdialogs/Utils.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.layout.Placeable
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 
 @Composable
 internal fun getString(@StringRes res: Int? = null, default: String? = null): String {
@@ -20,7 +21,7 @@ internal fun ThemedDialog(onCloseRequest: () -> Unit, children: @Composable () -
     val colors = MaterialTheme.colors
     val typography = MaterialTheme.typography
 
-    Dialog(onDismissRequest = onCloseRequest) {
+    Dialog(onDismissRequest = onCloseRequest, properties = DialogProperties(usePlatformDefaultWidth = true)) {
         MaterialTheme(colors = colors, typography = typography) {
             children()
         }


### PR DESCRIPTION
- Updates Compose to 1.0.0-rc01
- Fixes error that dialogs were always full-width when using Compose 1.0.0-rc01

They added a new dialog property `usePlatformDefaultWidth` that defaults to false which should be true if not wanting to use full-width for dialogs.