### PR TITLE
Added rememberMaterialDialog to the API and deprecated the build function

### DIFF
--- a/core/src/main/java/com/vanpra/composematerialdialogs/MaterialDialog.kt
+++ b/core/src/main/java/com/vanpra/composematerialdialogs/MaterialDialog.kt
@@ -171,6 +171,11 @@ class MaterialDialog(
      * @param elevation elevation of the dialog
      * @param content the body content of the dialog
      */
+    @Deprecated(
+        "Use instead the rememberMaterialDialog function.",
+        replaceWith = ReplaceWith("rememberMaterialDialog(backgroundColor, shape, " +
+                "border, elevation, buttons, content)")
+    )
     @Composable
     fun build(
         backgroundColor: Color = MaterialTheme.colors.surface,
@@ -252,4 +257,16 @@ class MaterialDialog(
             }
         }
     }
+}
+
+@Composable
+fun rememberMaterialDialog(
+    backgroundColor: Color = MaterialTheme.colors.surface,
+    shape: Shape = MaterialTheme.shapes.medium,
+    border: BorderStroke? = null,
+    elevation: Dp = 24.dp,
+    buttons: @Composable MaterialDialogButtons.() -> Unit = {},
+    content: @Composable MaterialDialog.() -> Unit,
+) = remember { MaterialDialog() }.apply {
+    build(backgroundColor, shape, border, elevation, buttons, content)
 }

--- a/core/src/main/java/com/vanpra/composematerialdialogs/MaterialDialog.kt
+++ b/core/src/main/java/com/vanpra/composematerialdialogs/MaterialDialog.kt
@@ -164,12 +164,7 @@ class MaterialDialog(
     }
 
     /**
-     *  Builds a dialog with the given content
-     * @param backgroundColor background color of the dialog
-     * @param shape shape of the dialog and components used in the dialog
-     * @param border border stoke of the dialog
-     * @param elevation elevation of the dialog
-     * @param content the body content of the dialog
+     * @see rememberMaterialDialog
      */
     @Deprecated(
         "Use instead the rememberMaterialDialog function.",
@@ -259,6 +254,14 @@ class MaterialDialog(
     }
 }
 
+/**
+ *  Builds a dialog with the given content
+ * @param backgroundColor background color of the dialog
+ * @param shape shape of the dialog and components used in the dialog
+ * @param border border stoke of the dialog
+ * @param elevation elevation of the dialog
+ * @param content the body content of the dialog
+ */
 @Composable
 fun rememberMaterialDialog(
     backgroundColor: Color = MaterialTheme.colors.surface,

--- a/core/src/main/java/com/vanpra/composematerialdialogs/MaterialDialog.kt
+++ b/core/src/main/java/com/vanpra/composematerialdialogs/MaterialDialog.kt
@@ -255,7 +255,25 @@ class MaterialDialog(
 }
 
 /**
- *  Builds a dialog with the given content
+ * Builds and remembers a dialog with the given content.
+ *
+ * Example:
+ *
+ * ```
+ * @Composable
+ * fun MyComposable() {
+ *     val myDialog = rememberMaterialDialog {
+ *         listItems(list = listOf("My item"))
+ *     }
+ *
+ *     Button(onClick = { myDialog.show() }) {
+ *         Text("Sample")
+ *     }
+ *
+ *     myDialog.show()
+ * }
+ * ```
+ *
  * @param backgroundColor background color of the dialog
  * @param shape shape of the dialog and components used in the dialog
  * @param border border stoke of the dialog


### PR DESCRIPTION
Little contribution: I've added `rememberMaterialDialog` following the Jetpack Compose API specifications and other examples from the JC API like `rememberBottomSheetState` etc.

I have also deprecated the build method, to be potentially removed/privatised at a certain point in order to help the users to use the right API.