### PR TITLE
Add DialogProperties parameter for resizing dialog content 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 0.6.2 - 2021-12-02
+
+-  Update compose to 1.1.0-beta04 ([#120](https://github.com/vanpra/compose-material-dialogs/issues/120))
+-  Update kotlin to 1.6.0
+
 ### 0.6.1 - 2021-10-07
 
   -  Update compose to 1.1.0-alpha05 ([#112](https://github.com/vanpra/compose-material-dialogs/issues/112) and [#110](https://github.com/vanpra/compose-material-dialogs/issues/110))

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/ae8d455118164f43a24732761a970cc8)](https://www.codacy.com/gh/vanpra/compose-material-dialogs/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=vanpra/compose-material-dialogs&amp;utm_campaign=Badge_Grade)![Build & Test](https://github.com/vanpra/compose-material-dialogs/actions/workflows/main.yml/badge.svg)
 
-**Current Library Compose Version: 1.1.0-alpha05**
+**Current Library Compose Version: 1.1.0-beta04**
 
 ### [See Releases and Changelog](https://github.com/vanpra/compose-material-dialogs/blob/main/CHANGELOG.md)
 
@@ -19,7 +19,7 @@
 ```gradle
 dependencies {
   ...
-  implementation "io.github.vanpra.compose-material-dialogs:core:0.6.1" 
+  implementation "io.github.vanpra.compose-material-dialogs:core:0.6.2" 
   ...
 }
 ```
@@ -35,7 +35,7 @@ dependencies {
 ```gradle
 dependencies {
   ...
-  implementation "io.github.vanpra.compose-material-dialogs:datetime:0.6.1"
+  implementation "io.github.vanpra.compose-material-dialogs:datetime:0.6.2"
   ...
 }
 ```
@@ -51,7 +51,7 @@ dependencies {
 ```gradle
 dependencies {
   ...
-  implementation "io.github.vanpra.compose-material-dialogs:color:0.6.1"
+  implementation "io.github.vanpra.compose-material-dialogs:color:0.6.2"
   ...
 }
 ```

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,7 +51,6 @@ dependencies {
 //    implementation(Dependencies.ComposeMaterialDialogs.datetime)
 //    implementation(Dependencies.ComposeMaterialDialogs.color)
 
-    implementation(Dependencies.Kotlin.stdlib)
     implementation(Dependencies.Google.material)
     implementation(Dependencies.AndroidX.coreKtx)
 
@@ -64,6 +63,5 @@ dependencies {
     implementation(Dependencies.AndroidX.Compose.activity)
     implementation(Dependencies.AndroidX.Compose.navigation)
 
-    implementation(kotlin("stdlib-jdk8"))
     coreLibraryDesugaring(Dependencies.desugar)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    id("com.diffplug.spotless") version "5.14.3"
+    id("com.diffplug.spotless") version "6.0.4"
     id("org.jetbrains.dokka") version "1.6.0"
 }
 
@@ -9,7 +9,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        maven("https://dl.bintray.com/kotlin/kotlin-eap")
         maven("https://plugins.gradle.org/m2/")
     }
 
@@ -27,9 +26,6 @@ allprojects {
         google()
         mavenCentral()
         gradlePluginPortal()
-        maven("https://dl.bintray.com/kotlin/kotlin-eap")
-        maven("https://kotlin.bintray.com/kotlinx/")
-        maven("https://s01.oss.sonatype.org/content/repositories/snapshots")
     }
 
     tasks.withType<KotlinCompile>().all {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,22 +2,22 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     id("com.diffplug.spotless") version "5.14.3"
-    id("org.jetbrains.dokka") version "1.5.0"
+    id("org.jetbrains.dokka") version "1.6.0"
 }
 
 buildscript {
     repositories {
         google()
         mavenCentral()
-        maven { url = uri("https://dl.bintray.com/kotlin/kotlin-eap") }
-        maven { url = uri("https://plugins.gradle.org/m2/") }
+        maven("https://dl.bintray.com/kotlin/kotlin-eap")
+        maven("https://plugins.gradle.org/m2/")
     }
 
     dependencies {
         classpath(Dependencies.Kotlin.gradlePlugin)
-        classpath("com.android.tools.build:gradle:7.1.0-alpha13")
+        classpath("com.android.tools.build:gradle:7.1.0-beta04")
         classpath("com.vanniktech:gradle-maven-publish-plugin:0.17.0")
-        classpath("org.jetbrains.dokka:dokka-gradle-plugin:1.5.0")
+        classpath("org.jetbrains.dokka:dokka-gradle-plugin:1.6.0")
         classpath(Dependencies.Shot.core)
     }
 }
@@ -27,9 +27,9 @@ allprojects {
         google()
         mavenCentral()
         gradlePluginPortal()
-        maven { url = uri("https://dl.bintray.com/kotlin/kotlin-eap") }
-        maven { url = uri("https://kotlin.bintray.com/kotlinx/") }
-        maven { url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots") }
+        maven("https://dl.bintray.com/kotlin/kotlin-eap")
+        maven("https://kotlin.bintray.com/kotlinx/")
+        maven("https://s01.oss.sonatype.org/content/repositories/snapshots")
     }
 
     tasks.withType<KotlinCompile>().all {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,7 +1,7 @@
 repositories {
     google()
     mavenCentral()
-    maven { url = uri("https://dl.bintray.com/kotlin/kotlin-eap") }
+    maven("https://dl.bintray.com/kotlin/kotlin-eap")
 }
 
 plugins {

--- a/buildSrc/src/main/kotlin/CommonModulePlugin.kt
+++ b/buildSrc/src/main/kotlin/CommonModulePlugin.kt
@@ -22,7 +22,6 @@ class CommonModulePlugin: Plugin<Project> {
 
     private fun Project.dependenciesConf() {
         dependencies.apply {
-            implementation(Dependencies.Kotlin.stdlib)
             implementation(Dependencies.AndroidX.coreKtx)
 
             implementation(Dependencies.AndroidX.Compose.ui)

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -2,7 +2,7 @@ object Dependencies {
     const val desugar = "com.android.tools:desugar_jdk_libs:1.1.5"
 
     object ComposeMaterialDialogs {
-        const val version = "0.6.2-SNAPSHOT"
+        const val version = "0.6.2"
 
         const val core = "io.github.vanpra.compose-material-dialogs:core:$version"
         const val datetime = "io.github.vanpra.compose-material-dialogs:datetime:$version"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -2,7 +2,7 @@ object Dependencies {
     const val desugar = "com.android.tools:desugar_jdk_libs:1.1.5"
 
     object ComposeMaterialDialogs {
-        const val version = "0.6.0"
+        const val version = "0.6.2-SNAPSHOT"
 
         const val core = "io.github.vanpra.compose-material-dialogs:core:$version"
         const val datetime = "io.github.vanpra.compose-material-dialogs:datetime:$version"
@@ -14,13 +14,12 @@ object Dependencies {
     }
 
     object Accompanist {
-        private const val version = "0.19.0"
+        private const val version = "0.20.2"
         const val pager = "com.google.accompanist:accompanist-pager:$version"
     }
 
     object Kotlin {
-        private const val version = "1.5.31"
-        const val stdlib = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$version"
+        private const val version = "1.6.0"
         const val gradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:$version"
     }
 
@@ -31,11 +30,11 @@ object Dependencies {
     }
 
     object Google {
-        const val material = "com.google.android.material:material:1.5.0-alpha04"
+        const val material = "com.google.android.material:material:1.5.0-beta01"
     }
 
     object AndroidX {
-        const val coreKtx = "androidx.core:core-ktx:1.7.0-beta02"
+        const val coreKtx = "androidx.core:core-ktx:1.7.0"
 
         object Testing {
             const val version = "1.4.1-alpha03"
@@ -45,7 +44,7 @@ object Dependencies {
         }
 
         object Compose {
-            const val version = "1.1.0-alpha05"
+            const val version = "1.1.0-beta04"
 
             const val ui = "androidx.compose.ui:ui:$version"
             const val material = "androidx.compose.material:material:$version"
@@ -55,8 +54,8 @@ object Dependencies {
             const val foundationLayout = "androidx.compose.foundation:foundation-layout:$version"
 
             const val testing = "androidx.compose.ui:ui-test-junit4:$version"
-            const val activity = "androidx.activity:activity-compose:1.4.0-beta01"
-            const val navigation = "androidx.navigation:navigation-compose:2.4.0-alpha10"
+            const val activity = "androidx.activity:activity-compose:1.4.0"
+            const val navigation = "androidx.navigation:navigation-compose:2.4.0-beta02"
         }
     }
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -14,7 +14,7 @@ object Dependencies {
     }
 
     object Accompanist {
-        private const val version = "0.20.2"
+        private const val version = "0.21.4-beta"
         const val pager = "com.google.accompanist:accompanist-pager:$version"
     }
 

--- a/core/src/main/java/com/vanpra/composematerialdialogs/MaterialDialog.kt
+++ b/core/src/main/java/com/vanpra/composematerialdialogs/MaterialDialog.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.math.min
 
@@ -204,6 +205,7 @@ fun rememberMaterialDialogState(initialValue: Boolean = false): MaterialDialogSt
 /**
  *  Builds a dialog with the given content
  * @param dialogState state of the dialog
+ * @param properties properties of the compose dialog
  * @param backgroundColor background color of the dialog
  * @param shape shape of the dialog and components used in the dialog
  * @param border border stoke of the dialog
@@ -216,6 +218,7 @@ fun rememberMaterialDialogState(initialValue: Boolean = false): MaterialDialogSt
 @Composable
 fun MaterialDialog(
     dialogState: MaterialDialogState = rememberMaterialDialogState(),
+    properties: DialogProperties = DialogProperties(),
     backgroundColor: Color = MaterialTheme.colors.surface,
     shape: Shape = MaterialTheme.shapes.medium,
     border: BorderStroke? = null,
@@ -248,7 +251,10 @@ fun MaterialDialog(
                 elevation = elevation
             ) ?: MaterialTheme.colors.surface
 
-            Dialog(onDismissRequest = { onCloseRequest(dialogState) }) {
+            Dialog(
+                properties = properties,
+                onDismissRequest = { onCloseRequest(dialogState) }
+            ) {
                 Surface(
                     modifier = Modifier
                         .fillMaxWidth()

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ android.enableJetifier=false
 kotlin.code.style=official
 
 GROUP=io.github.vanpra.compose-material-dialogs
-VERSION_NAME=0.6.1
+VERSION_NAME=0.6.2-SNAPSHOT
 
 POM_DESCRIPTION=A Material Dialog Builder for Jetpack Compose
 POM_INCEPTION_YEAR=2020

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ android.enableJetifier=false
 kotlin.code.style=official
 
 GROUP=io.github.vanpra.compose-material-dialogs
-VERSION_NAME=0.6.2-SNAPSHOT
+VERSION_NAME=0.6.2
 
 POM_DESCRIPTION=A Material Dialog Builder for Jetpack Compose
 POM_INCEPTION_YEAR=2020

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Feb 05 10:11:42 GMT 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/test-utils/build.gradle.kts
+++ b/test-utils/build.gradle.kts
@@ -50,7 +50,6 @@ android {
 
 dependencies {
     api(project(":core"))
-    implementation(Dependencies.Kotlin.stdlib)
 
     implementation(Dependencies.AndroidX.Compose.ui)
     implementation(Dependencies.AndroidX.Compose.material)


### PR DESCRIPTION
We ran into a known issue with Jetpack Compose Dialogs:
When you have dialog content that may change it's height dynamically, the dialog does not resize it's height at all and content is clipped.
Possible use cases with dynamic height:
- AnimatedVisibility
- Text that is changing while Dialog is visible (because of user interaction)
- Using a camera inside a dialog, first requesting permission and changing the content afterwards

Also see
- https://issuetracker.google.com/issues/194911971
- https://stackoverflow.com/questions/68469681/jetpack-compose-layout-changes-in-dialog-doesnt-update-the-size
- https://stackoverflow.com/questions/68818202/animatedvisibility-doesnt-expand-height-in-dialog-in-jetpack-compose

Luckily, there is a workaround for this bug (which appeared in compose 1.0.0-rc02 and isn't fixed until now - 1.1.0-beta02).
One has to pass `DialogProperties(usePlatformDefaultWidth = false)`, which doesn't make any sense but actually works.

This pull request adds a `properties` parameter to MaterialDialog to be able to use this workaround, which seems to be required during at least the lifecycle of compose 1.1.0, too.