### PR TITLE
Upgrade: Compose 1.1.0-beta04, Kotlin 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 0.6.2 - 2021-12-02
+
+-  Update compose to 1.1.0-beta04 ([#120](https://github.com/vanpra/compose-material-dialogs/issues/120))
+-  Update kotlin to 1.6.0
+
 ### 0.6.1 - 2021-10-07
 
   -  Update compose to 1.1.0-alpha05 ([#112](https://github.com/vanpra/compose-material-dialogs/issues/112) and [#110](https://github.com/vanpra/compose-material-dialogs/issues/110))

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/ae8d455118164f43a24732761a970cc8)](https://www.codacy.com/gh/vanpra/compose-material-dialogs/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=vanpra/compose-material-dialogs&amp;utm_campaign=Badge_Grade)![Build & Test](https://github.com/vanpra/compose-material-dialogs/actions/workflows/main.yml/badge.svg)
 
-**Current Library Compose Version: 1.1.0-alpha05**
+**Current Library Compose Version: 1.1.0-beta04**
 
 ### [See Releases and Changelog](https://github.com/vanpra/compose-material-dialogs/blob/main/CHANGELOG.md)
 
@@ -19,7 +19,7 @@
 ```gradle
 dependencies {
   ...
-  implementation "io.github.vanpra.compose-material-dialogs:core:0.6.1" 
+  implementation "io.github.vanpra.compose-material-dialogs:core:0.6.2" 
   ...
 }
 ```
@@ -35,7 +35,7 @@ dependencies {
 ```gradle
 dependencies {
   ...
-  implementation "io.github.vanpra.compose-material-dialogs:datetime:0.6.1"
+  implementation "io.github.vanpra.compose-material-dialogs:datetime:0.6.2"
   ...
 }
 ```
@@ -51,7 +51,7 @@ dependencies {
 ```gradle
 dependencies {
   ...
-  implementation "io.github.vanpra.compose-material-dialogs:color:0.6.1"
+  implementation "io.github.vanpra.compose-material-dialogs:color:0.6.2"
   ...
 }
 ```

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,7 +51,6 @@ dependencies {
 //    implementation(Dependencies.ComposeMaterialDialogs.datetime)
 //    implementation(Dependencies.ComposeMaterialDialogs.color)
 
-    implementation(Dependencies.Kotlin.stdlib)
     implementation(Dependencies.Google.material)
     implementation(Dependencies.AndroidX.coreKtx)
 
@@ -64,6 +63,5 @@ dependencies {
     implementation(Dependencies.AndroidX.Compose.activity)
     implementation(Dependencies.AndroidX.Compose.navigation)
 
-    implementation(kotlin("stdlib-jdk8"))
     coreLibraryDesugaring(Dependencies.desugar)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    id("com.diffplug.spotless") version "5.14.3"
+    id("com.diffplug.spotless") version "6.0.4"
     id("org.jetbrains.dokka") version "1.6.0"
 }
 
@@ -9,7 +9,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        maven("https://dl.bintray.com/kotlin/kotlin-eap")
         maven("https://plugins.gradle.org/m2/")
     }
 
@@ -27,9 +26,6 @@ allprojects {
         google()
         mavenCentral()
         gradlePluginPortal()
-        maven("https://dl.bintray.com/kotlin/kotlin-eap")
-        maven("https://kotlin.bintray.com/kotlinx/")
-        maven("https://s01.oss.sonatype.org/content/repositories/snapshots")
     }
 
     tasks.withType<KotlinCompile>().all {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,22 +2,22 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     id("com.diffplug.spotless") version "5.14.3"
-    id("org.jetbrains.dokka") version "1.5.0"
+    id("org.jetbrains.dokka") version "1.6.0"
 }
 
 buildscript {
     repositories {
         google()
         mavenCentral()
-        maven { url = uri("https://dl.bintray.com/kotlin/kotlin-eap") }
-        maven { url = uri("https://plugins.gradle.org/m2/") }
+        maven("https://dl.bintray.com/kotlin/kotlin-eap")
+        maven("https://plugins.gradle.org/m2/")
     }
 
     dependencies {
         classpath(Dependencies.Kotlin.gradlePlugin)
-        classpath("com.android.tools.build:gradle:7.1.0-alpha13")
+        classpath("com.android.tools.build:gradle:7.1.0-beta04")
         classpath("com.vanniktech:gradle-maven-publish-plugin:0.17.0")
-        classpath("org.jetbrains.dokka:dokka-gradle-plugin:1.5.0")
+        classpath("org.jetbrains.dokka:dokka-gradle-plugin:1.6.0")
         classpath(Dependencies.Shot.core)
     }
 }
@@ -27,9 +27,9 @@ allprojects {
         google()
         mavenCentral()
         gradlePluginPortal()
-        maven { url = uri("https://dl.bintray.com/kotlin/kotlin-eap") }
-        maven { url = uri("https://kotlin.bintray.com/kotlinx/") }
-        maven { url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots") }
+        maven("https://dl.bintray.com/kotlin/kotlin-eap")
+        maven("https://kotlin.bintray.com/kotlinx/")
+        maven("https://s01.oss.sonatype.org/content/repositories/snapshots")
     }
 
     tasks.withType<KotlinCompile>().all {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,7 +1,7 @@
 repositories {
     google()
     mavenCentral()
-    maven { url = uri("https://dl.bintray.com/kotlin/kotlin-eap") }
+    maven("https://dl.bintray.com/kotlin/kotlin-eap")
 }
 
 plugins {

--- a/buildSrc/src/main/kotlin/CommonModulePlugin.kt
+++ b/buildSrc/src/main/kotlin/CommonModulePlugin.kt
@@ -22,7 +22,6 @@ class CommonModulePlugin: Plugin<Project> {
 
     private fun Project.dependenciesConf() {
         dependencies.apply {
-            implementation(Dependencies.Kotlin.stdlib)
             implementation(Dependencies.AndroidX.coreKtx)
 
             implementation(Dependencies.AndroidX.Compose.ui)

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -2,7 +2,7 @@ object Dependencies {
     const val desugar = "com.android.tools:desugar_jdk_libs:1.1.5"
 
     object ComposeMaterialDialogs {
-        const val version = "0.6.2-SNAPSHOT"
+        const val version = "0.6.2"
 
         const val core = "io.github.vanpra.compose-material-dialogs:core:$version"
         const val datetime = "io.github.vanpra.compose-material-dialogs:datetime:$version"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -2,7 +2,7 @@ object Dependencies {
     const val desugar = "com.android.tools:desugar_jdk_libs:1.1.5"
 
     object ComposeMaterialDialogs {
-        const val version = "0.6.0"
+        const val version = "0.6.2-SNAPSHOT"
 
         const val core = "io.github.vanpra.compose-material-dialogs:core:$version"
         const val datetime = "io.github.vanpra.compose-material-dialogs:datetime:$version"
@@ -14,13 +14,12 @@ object Dependencies {
     }
 
     object Accompanist {
-        private const val version = "0.19.0"
+        private const val version = "0.20.2"
         const val pager = "com.google.accompanist:accompanist-pager:$version"
     }
 
     object Kotlin {
-        private const val version = "1.5.31"
-        const val stdlib = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$version"
+        private const val version = "1.6.0"
         const val gradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:$version"
     }
 
@@ -31,11 +30,11 @@ object Dependencies {
     }
 
     object Google {
-        const val material = "com.google.android.material:material:1.5.0-alpha04"
+        const val material = "com.google.android.material:material:1.5.0-beta01"
     }
 
     object AndroidX {
-        const val coreKtx = "androidx.core:core-ktx:1.7.0-beta02"
+        const val coreKtx = "androidx.core:core-ktx:1.7.0"
 
         object Testing {
             const val version = "1.4.1-alpha03"
@@ -45,7 +44,7 @@ object Dependencies {
         }
 
         object Compose {
-            const val version = "1.1.0-alpha05"
+            const val version = "1.1.0-beta04"
 
             const val ui = "androidx.compose.ui:ui:$version"
             const val material = "androidx.compose.material:material:$version"
@@ -55,8 +54,8 @@ object Dependencies {
             const val foundationLayout = "androidx.compose.foundation:foundation-layout:$version"
 
             const val testing = "androidx.compose.ui:ui-test-junit4:$version"
-            const val activity = "androidx.activity:activity-compose:1.4.0-beta01"
-            const val navigation = "androidx.navigation:navigation-compose:2.4.0-alpha10"
+            const val activity = "androidx.activity:activity-compose:1.4.0"
+            const val navigation = "androidx.navigation:navigation-compose:2.4.0-beta02"
         }
     }
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -14,7 +14,7 @@ object Dependencies {
     }
 
     object Accompanist {
-        private const val version = "0.20.2"
+        private const val version = "0.21.4-beta"
         const val pager = "com.google.accompanist:accompanist-pager:$version"
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ android.enableJetifier=false
 kotlin.code.style=official
 
 GROUP=io.github.vanpra.compose-material-dialogs
-VERSION_NAME=0.6.1
+VERSION_NAME=0.6.2-SNAPSHOT
 
 POM_DESCRIPTION=A Material Dialog Builder for Jetpack Compose
 POM_INCEPTION_YEAR=2020

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ android.enableJetifier=false
 kotlin.code.style=official
 
 GROUP=io.github.vanpra.compose-material-dialogs
-VERSION_NAME=0.6.2-SNAPSHOT
+VERSION_NAME=0.6.2
 
 POM_DESCRIPTION=A Material Dialog Builder for Jetpack Compose
 POM_INCEPTION_YEAR=2020

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Feb 05 10:11:42 GMT 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/test-utils/build.gradle.kts
+++ b/test-utils/build.gradle.kts
@@ -50,7 +50,6 @@ android {
 
 dependencies {
     api(project(":core"))
-    implementation(Dependencies.Kotlin.stdlib)
 
     implementation(Dependencies.AndroidX.Compose.ui)
     implementation(Dependencies.AndroidX.Compose.material)


### PR DESCRIPTION
Closes #120 
Will need to change the 0.6.2-SNAPSHOT to 0.6.2 or greater. I did snapshot to allow publishToMavenLocal to work in my setup without requiring signing.
There is also some minor cleanup in portions of the build.gradle.kts stuff.
So far only datepicker tested.