### PR TITLE
Update Compose to 1.2.0-alpha03

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -14,12 +14,12 @@ object Dependencies {
     }
 
     object Accompanist {
-        private const val version = "0.22.0-rc"
+        private const val version = "0.24.2-alpha"
         const val pager = "com.google.accompanist:accompanist-pager:$version"
     }
 
     object Kotlin {
-        private const val version = "1.6.0"
+        private const val version = "1.6.10"
         const val gradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:$version"
     }
 
@@ -37,14 +37,14 @@ object Dependencies {
         const val coreKtx = "androidx.core:core-ktx:1.7.0"
 
         object Testing {
-            const val version = "1.4.1-alpha03"
+            const val version = "1.4.1-alpha04"
             const val core = "androidx.test:core:$version"
             const val rules = "androidx.test:rules:$version"
             const val runner = "androidx.test:runner:$version"
         }
 
         object Compose {
-            const val version = "1.1.0-rc01"
+            const val version = "1.2.0-alpha03"
 
             const val ui = "androidx.compose.ui:ui:$version"
             const val material = "androidx.compose.material:material:$version"
@@ -54,8 +54,8 @@ object Dependencies {
             const val foundationLayout = "androidx.compose.foundation:foundation-layout:$version"
 
             const val testing = "androidx.compose.ui:ui-test-junit4:$version"
-            const val activity = "androidx.activity:activity-compose:1.4.0"
-            const val navigation = "androidx.navigation:navigation-compose:2.4.0-rc01"
+            const val activity = "androidx.activity:activity-compose:1.5.0-alpha02"
+            const val navigation = "androidx.navigation:navigation-compose:2.5.0-alpha02"
         }
     }
 }

--- a/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/date/DatePicker.kt
+++ b/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/date/DatePicker.kt
@@ -20,11 +20,7 @@ import androidx.compose.foundation.layout.paddingFromBaseline
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.foundation.lazy.GridCells
-import androidx.compose.foundation.lazy.LazyVerticalGrid
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ContentAlpha
@@ -152,7 +148,7 @@ private fun YearPicker(
     state: DatePickerState,
     pagerState: PagerState,
 ) {
-    val gridState = rememberLazyListState((viewDate.year - state.yearRange.first) / 3)
+    val gridState = rememberLazyGridState((viewDate.year - state.yearRange.first) / 3)
     val coroutineScope = rememberCoroutineScope()
 
     LazyVerticalGrid(


### PR DESCRIPTION
Switches to Kotlin Gradle Plugin 1.6.0 and uses latest compose version `1.2.0-alpha03`.

# Description

This library doesn't work with the latest Compose version `1.2.0-alpha03`. The issue is with the new `LazyGridState` being introduced.

This PR updates it so it works. I understand that you might not want to merge into the main branch since this is alpha version of compose, but I believe a lot of people are on this version so I'm sharing in case it helps someone.