### PR TITLE
Internationalize day-of-week in calendar

### DIFF
--- a/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/date/DatePicker.kt
+++ b/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/date/DatePicker.kt
@@ -62,6 +62,7 @@ import com.vanpra.composematerialdialogs.datetime.util.shortLocalName
 import kotlinx.coroutines.launch
 import java.time.LocalDate
 import java.time.format.TextStyle.FULL
+import java.time.temporal.WeekFields
 import java.util.Locale
 
 /**
@@ -432,7 +433,9 @@ private fun CalendarHeader(title: String, state: DatePickerState) {
 
 private fun getDates(date: LocalDate): Pair<Int, Int> {
     val numDays = date.month.length(date.isLeapYear)
-    val firstDay = date.withDayOfMonth(1).dayOfWeek.value % 7
+
+    val firstDayOfWeek = WeekFields.of(Locale.getDefault()).getFirstDayOfWeek().value
+    val firstDay = date.withDayOfMonth(1).dayOfWeek.value - firstDayOfWeek % 7
 
     return Pair(firstDay, numDays)
 }

--- a/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/date/DatePickerState.kt
+++ b/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/date/DatePickerState.kt
@@ -5,12 +5,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.Color
-import java.text.DateFormat
-import java.text.SimpleDateFormat
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.temporal.WeekFields
-import java.util.*
+import java.util.Calendar
+import java.util.Locale
 
 internal class DatePickerState(
     initialDate: LocalDate,
@@ -37,8 +36,6 @@ internal class DatePickerState(
 
         val dayHeaders = WeekFields.of(locale).firstDayOfWeek.let { firstDayOfWeek ->
             (0L until 7L).map {
-                println(firstDayOfWeek.plus(it))
-                println(isoDayOfWeekToCalendarDayOfWeek[firstDayOfWeek.plus(it)] )
                 DateUtils.getDayOfWeekString(isoDayOfWeekToCalendarDayOfWeek[firstDayOfWeek.plus(it)] ?: 0, DateUtils.LENGTH_SHORTEST)
             }
         }

--- a/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/date/DatePickerState.kt
+++ b/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/date/DatePickerState.kt
@@ -1,14 +1,12 @@
 package com.vanpra.composematerialdialogs.datetime.date
 
-import android.text.format.DateUtils
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.Color
-import java.time.DayOfWeek
 import java.time.LocalDate
+import java.time.format.TextStyle
 import java.time.temporal.WeekFields
-import java.util.Calendar
 import java.util.Locale
 
 internal class DatePickerState(
@@ -24,19 +22,9 @@ internal class DatePickerState(
 
         private val locale = Locale.getDefault()
 
-        private val isoDayOfWeekToCalendarDayOfWeek = mapOf(
-            DayOfWeek.MONDAY to Calendar.MONDAY,
-            DayOfWeek.TUESDAY to Calendar.TUESDAY,
-            DayOfWeek.WEDNESDAY to Calendar.WEDNESDAY,
-            DayOfWeek.THURSDAY to Calendar.THURSDAY,
-            DayOfWeek.FRIDAY to Calendar.FRIDAY,
-            DayOfWeek.SATURDAY to Calendar.SATURDAY,
-            DayOfWeek.SUNDAY to Calendar.SUNDAY
-        )
-
         val dayHeaders = WeekFields.of(locale).firstDayOfWeek.let { firstDayOfWeek ->
             (0L until 7L).map {
-                DateUtils.getDayOfWeekString(isoDayOfWeekToCalendarDayOfWeek[firstDayOfWeek.plus(it)] ?: 0, DateUtils.LENGTH_SHORTEST)
+                firstDayOfWeek.plus(it).getDisplayName(TextStyle.NARROW, locale)
             }
         }
     }

--- a/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/date/DatePickerState.kt
+++ b/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/date/DatePickerState.kt
@@ -1,10 +1,16 @@
 package com.vanpra.composematerialdialogs.datetime.date
 
+import android.text.format.DateUtils
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.Color
+import java.text.DateFormat
+import java.text.SimpleDateFormat
+import java.time.DayOfWeek
 import java.time.LocalDate
+import java.time.temporal.WeekFields
+import java.util.*
 
 internal class DatePickerState(
     initialDate: LocalDate,
@@ -16,6 +22,25 @@ internal class DatePickerState(
     var yearPickerShowing by mutableStateOf(false)
 
     companion object {
-        val dayHeaders = listOf("S", "M", "T", "W", "T", "F", "S")
+
+        private val locale = Locale.getDefault()
+
+        private val isoDayOfWeekToCalendarDayOfWeek = mapOf(
+            DayOfWeek.MONDAY to Calendar.MONDAY,
+            DayOfWeek.TUESDAY to Calendar.TUESDAY,
+            DayOfWeek.WEDNESDAY to Calendar.WEDNESDAY,
+            DayOfWeek.THURSDAY to Calendar.THURSDAY,
+            DayOfWeek.FRIDAY to Calendar.FRIDAY,
+            DayOfWeek.SATURDAY to Calendar.SATURDAY,
+            DayOfWeek.SUNDAY to Calendar.SUNDAY
+        )
+
+        val dayHeaders = WeekFields.of(locale).firstDayOfWeek.let { firstDayOfWeek ->
+            (0L until 7L).map {
+                println(firstDayOfWeek.plus(it))
+                println(isoDayOfWeekToCalendarDayOfWeek[firstDayOfWeek.plus(it)] )
+                DateUtils.getDayOfWeekString(isoDayOfWeekToCalendarDayOfWeek[firstDayOfWeek.plus(it)] ?: 0, DateUtils.LENGTH_SHORTEST)
+            }
+        }
     }
 }


### PR DESCRIPTION
# Description

This change introduces internationalized DayOfWeekHeader in calendar with respect to countries using other firstDayOfWeeks than Sunday.
This also generates the DayOfWeekHeader instead of hardcoding to english locale. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update/fix

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit and screenshot tests pass locally with my changes