### PR TITLE
Locale can be provided from outside, proper locale handling in date picker 

### DIFF
--- a/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/date/DatePicker.kt
+++ b/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/date/DatePicker.kt
@@ -56,11 +56,11 @@ import com.google.accompanist.pager.HorizontalPager
 import com.google.accompanist.pager.PagerState
 import com.google.accompanist.pager.rememberPagerState
 import com.vanpra.composematerialdialogs.MaterialDialogScope
+import com.vanpra.composematerialdialogs.datetime.util.getFullLocalName
+import com.vanpra.composematerialdialogs.datetime.util.getShortLocalName
 import com.vanpra.composematerialdialogs.datetime.util.isSmallDevice
-import com.vanpra.composematerialdialogs.datetime.util.shortLocalName
 import kotlinx.coroutines.launch
 import java.time.LocalDate
-import java.time.format.TextStyle.FULL
 import java.time.temporal.WeekFields
 import java.util.Locale
 
@@ -83,13 +83,14 @@ fun MaterialDialogScope.datepicker(
     yearRange: IntRange = IntRange(1900, 2100),
     waitForPositiveButton: Boolean = true,
     allowedDateValidator: (LocalDate) -> Boolean = { true },
+    locale: Locale = Locale.getDefault(),
     onDateChange: (LocalDate) -> Unit = {}
 ) {
     val datePickerState = remember {
         DatePickerState(initialDate, colors, yearRange, dialogState.dialogBackgroundColor!!)
     }
 
-    DatePickerImpl(title = title, state = datePickerState, allowedDateValidator)
+    DatePickerImpl(title = title, state = datePickerState, allowedDateValidator, locale)
 
     if (waitForPositiveButton) {
         DialogCallback { onDateChange(datePickerState.selected) }
@@ -106,14 +107,15 @@ fun MaterialDialogScope.datepicker(
 internal fun DatePickerImpl(
     title: String,
     state: DatePickerState,
-    allowedDateValidator: (LocalDate) -> Boolean
+    allowedDateValidator: (LocalDate) -> Boolean,
+    locale: Locale
 ) {
     val pagerState = rememberPagerState(
         initialPage = (state.selected.year - state.yearRange.first) * 12 + state.selected.monthValue - 1
     )
 
     Column(Modifier.fillMaxWidth()) {
-        CalendarHeader(title, state)
+        CalendarHeader(title, state, locale)
         HorizontalPager(
             count = (state.yearRange.last - state.yearRange.first + 1) * 12,
             state = pagerState,
@@ -129,7 +131,7 @@ internal fun DatePickerImpl(
             }
 
             Column {
-                CalendarViewHeader(viewDate, state, pagerState)
+                CalendarViewHeader(viewDate, state, pagerState, locale)
                 Box {
                     androidx.compose.animation.AnimatedVisibility(
                         state.yearPickerShowing,
@@ -142,7 +144,7 @@ internal fun DatePickerImpl(
                         YearPicker(viewDate, state, pagerState)
                     }
 
-                    CalendarView(viewDate, state, allowedDateValidator)
+                    CalendarView(viewDate, state, locale, allowedDateValidator)
                 }
             }
         }
@@ -216,10 +218,11 @@ private fun YearPickerItem(
 private fun CalendarViewHeader(
     viewDate: LocalDate,
     state: DatePickerState,
-    pagerState: PagerState
+    pagerState: PagerState,
+    locale: Locale
 ) {
     val coroutineScope = rememberCoroutineScope()
-    val month = remember { viewDate.month.getDisplayName(FULL, Locale.getDefault()) }
+    val month = remember { viewDate.month.getFullLocalName(locale) }
     val yearDropdownIcon = remember(state.yearPickerShowing) {
         if (state.yearPickerShowing) Icons.Default.ArrowDropUp else Icons.Default.ArrowDropDown
     }
@@ -304,6 +307,7 @@ private fun CalendarViewHeader(
 private fun CalendarView(
     viewDate: LocalDate,
     state: DatePickerState,
+    locale: Locale,
     allowedDateValidator: (LocalDate) -> Boolean
 ) {
     Column(
@@ -311,8 +315,8 @@ private fun CalendarView(
             .padding(start = 12.dp, end = 12.dp)
             .testTag("dialog_date_calendar")
     ) {
-        DayOfWeekHeader(state)
-        val calendarDatesData = remember { getDates(viewDate) }
+        DayOfWeekHeader(state, locale)
+        val calendarDatesData = remember { getDates(viewDate, locale) }
         val datesList = remember { IntRange(1, calendarDatesData.second).toList() }
         val possibleSelected = remember(state.selected) {
             viewDate.year == state.selected.year && viewDate.month == state.selected.month
@@ -374,7 +378,13 @@ private fun DateSelectionBox(
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-private fun DayOfWeekHeader(state: DatePickerState) {
+private fun DayOfWeekHeader(state: DatePickerState, locale: Locale) {
+    val dayHeaders = WeekFields.of(locale).firstDayOfWeek.let { firstDayOfWeek ->
+        (0L until 7L).map {
+            firstDayOfWeek.plus(it).getDisplayName(java.time.format.TextStyle.NARROW, locale)
+        }
+    }
+
     Row(
         modifier = Modifier
             .height(40.dp)
@@ -383,7 +393,7 @@ private fun DayOfWeekHeader(state: DatePickerState) {
         horizontalArrangement = Arrangement.SpaceEvenly
     ) {
         LazyVerticalGrid(cells = GridCells.Fixed(7)) {
-            DatePickerState.dayHeaders.forEach { it ->
+            dayHeaders.forEach { it ->
                 item {
                     Box(Modifier.size(40.dp)) {
                         Text(
@@ -403,9 +413,9 @@ private fun DayOfWeekHeader(state: DatePickerState) {
 }
 
 @Composable
-private fun CalendarHeader(title: String, state: DatePickerState) {
-    val month = remember(state.selected) { state.selected.month.shortLocalName }
-    val day = remember(state.selected) { state.selected.dayOfWeek.shortLocalName }
+private fun CalendarHeader(title: String, state: DatePickerState, locale: Locale) {
+    val month = remember(state.selected) { state.selected.month.getShortLocalName(locale) }
+    val day = remember(state.selected) { state.selected.dayOfWeek.getShortLocalName(locale) }
 
     Box(
         Modifier
@@ -438,10 +448,10 @@ private fun CalendarHeader(title: String, state: DatePickerState) {
     }
 }
 
-private fun getDates(date: LocalDate): Pair<Int, Int> {
+private fun getDates(date: LocalDate, locale: Locale): Pair<Int, Int> {
     val numDays = date.month.length(date.isLeapYear)
 
-    val firstDayOfWeek = WeekFields.of(Locale.getDefault()).getFirstDayOfWeek().value
+    val firstDayOfWeek = WeekFields.of(locale).firstDayOfWeek.value
     val firstDay = date.withDayOfMonth(1).dayOfWeek.value - firstDayOfWeek % 7
 
     return Pair(firstDay, numDays)

--- a/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/date/DatePickerState.kt
+++ b/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/date/DatePickerState.kt
@@ -5,9 +5,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.Color
 import java.time.LocalDate
-import java.time.format.TextStyle
-import java.time.temporal.WeekFields
-import java.util.Locale
 
 internal class DatePickerState(
     initialDate: LocalDate,
@@ -17,15 +14,4 @@ internal class DatePickerState(
 ) {
     var selected by mutableStateOf(initialDate)
     var yearPickerShowing by mutableStateOf(false)
-
-    companion object {
-
-        private val locale = Locale.getDefault()
-
-        val dayHeaders = WeekFields.of(locale).firstDayOfWeek.let { firstDayOfWeek ->
-            (0L until 7L).map {
-                firstDayOfWeek.plus(it).getDisplayName(TextStyle.NARROW, locale)
-            }
-        }
-    }
 }

--- a/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/util/Extensions.kt
+++ b/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/util/Extensions.kt
@@ -16,15 +16,6 @@ internal fun Float.getOffset(angle: Double): Offset =
 internal val LocalDate.yearMonth: YearMonth
     get() = YearMonth.of(this.year, this.month)
 
-internal val Month.fullLocalName: String
-    get() = this.getDisplayName(java.time.format.TextStyle.FULL, Locale.getDefault())
-
-internal val Month.shortLocalName: String
-    get() = this.getDisplayName(java.time.format.TextStyle.SHORT, Locale.getDefault())
-
-internal val DayOfWeek.shortLocalName: String
-    get() = this.getDisplayName(java.time.format.TextStyle.SHORT, Locale.getDefault())
-
 internal val LocalTime.isAM: Boolean
     get() = this.hour in 0..11
 
@@ -33,6 +24,10 @@ internal val LocalTime.simpleHour: Int
         val tempHour = this.hour % 12
         return if (tempHour == 0) 12 else tempHour
     }
+
+internal fun Month.getShortLocalName(locale: Locale): String = this.getDisplayName(java.time.format.TextStyle.SHORT, locale)
+internal fun Month.getFullLocalName(locale: Locale) = this.getDisplayName(java.time.format.TextStyle.FULL, locale)
+internal fun DayOfWeek.getShortLocalName(locale: Locale) = this.getDisplayName(java.time.format.TextStyle.SHORT, locale)
 
 internal fun LocalTime.toAM(): LocalTime = if (this.isAM) this else this.minusHours(12)
 internal fun LocalTime.toPM(): LocalTime = if (!this.isAM) this else this.plusHours(12)


### PR DESCRIPTION
# Description

Proper locale handling in date picker. 
Allows passing locale from outside and that is useful for apps that have their own locale settings inside.

adds to improvment #54 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update/fix

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit and screenshot tests pass locally with my changes