### PR TITLE
Fix month name formatting for the languages with complex system of declensions

### DIFF
--- a/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/util/Extensions.kt
+++ b/datetime/src/main/java/com/vanpra/composematerialdialogs/datetime/util/Extensions.kt
@@ -29,7 +29,7 @@ internal fun Month.getShortLocalName(locale: Locale): String =
     this.getDisplayName(java.time.format.TextStyle.SHORT, locale)
 
 internal fun Month.getFullLocalName(locale: Locale) =
-    this.getDisplayName(java.time.format.TextStyle.FULL, locale)
+    this.getDisplayName(java.time.format.TextStyle.FULL_STANDALONE, locale)
 
 internal fun DayOfWeek.getShortLocalName(locale: Locale) =
     this.getDisplayName(java.time.format.TextStyle.SHORT, locale)


### PR DESCRIPTION
# Description

Name of 6th month in Russian, obtained using TextStyle.FULL, translates as 'of june' (like 'first of june' but without day), but TextStyle.FULL_STANDALONE produces correct name. The situation is the same in some other languages.

## Type of change

Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit and screenshot tests pass locally with my changes