### PR TITLE
Fix extra row bug on even number of colors

### DIFF
--- a/color/src/main/java/com/vanpra/composematerialdialogs/color/ColorPicker.kt
+++ b/color/src/main/java/com/vanpra/composematerialdialogs/color/ColorPicker.kt
@@ -1,5 +1,6 @@
 package com.vanpra.composematerialdialogs.color
 
+import android.util.Log
 import android.view.View
 import android.widget.FrameLayout
 import androidx.compose.foundation.Canvas
@@ -473,8 +474,10 @@ private fun GridView(
                     val spacing =
                         (constraints.maxWidth - (itemSize * itemsInRow)) / (itemsInRow - 1)
                     val additionalRow = measurables.size % 2
-                    val rows = (measurables.size / itemsInRow) + additionalRow
+                    val rows = maxOf((measurables.size / itemsInRow) + additionalRow, 1)
                     val layoutHeight = (rows * itemSize) + ((rows - 1) * spacing)
+
+                    Log.d("ColorPicker", "$additionalRow and ${measurables.size / itemsInRow}")
 
                     layout(constraints.maxWidth, layoutHeight) {
                         measurables

--- a/color/src/main/java/com/vanpra/composematerialdialogs/color/ColorPicker.kt
+++ b/color/src/main/java/com/vanpra/composematerialdialogs/color/ColorPicker.kt
@@ -1,6 +1,5 @@
 package com.vanpra.composematerialdialogs.color
 
-import android.util.Log
 import android.view.View
 import android.widget.FrameLayout
 import androidx.compose.foundation.Canvas
@@ -476,8 +475,6 @@ private fun GridView(
                     val additionalRow = measurables.size % 2
                     val rows = maxOf((measurables.size / itemsInRow) + additionalRow, 1)
                     val layoutHeight = (rows * itemSize) + ((rows - 1) * spacing)
-
-                    Log.d("ColorPicker", "$additionalRow and ${measurables.size / itemsInRow}")
 
                     layout(constraints.maxWidth, layoutHeight) {
                         measurables

--- a/color/src/main/java/com/vanpra/composematerialdialogs/color/ColorPicker.kt
+++ b/color/src/main/java/com/vanpra/composematerialdialogs/color/ColorPicker.kt
@@ -472,8 +472,8 @@ private fun GridView(
                 ) { measurables, constraints ->
                     val spacing =
                         (constraints.maxWidth - (itemSize * itemsInRow)) / (itemsInRow - 1)
-                    val rows = (measurables.size / itemsInRow) + 1
-
+                    val additionalRow = measurables.size % 2
+                    val rows = (measurables.size / itemsInRow) + additionalRow
                     val layoutHeight = (rows * itemSize) + ((rows - 1) * spacing)
 
                     layout(constraints.maxWidth, layoutHeight) {

--- a/core/src/main/java/com/vanpra/composematerialdialogs/MaterialDialogButtons.kt
+++ b/core/src/main/java/com/vanpra/composematerialdialogs/MaterialDialogButtons.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.material.ButtonColors
+import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
@@ -125,6 +127,7 @@ class MaterialDialogButtons(private val scope: MaterialDialogScope) {
         text: String? = null,
         textStyle: TextStyle = MaterialTheme.typography.button,
         @StringRes res: Int? = null,
+        colors: ButtonColors = ButtonDefaults.textButtonColors(),
         onClick: () -> Unit = {}
     ) {
         val buttonText = getString(res, text).uppercase(Locale.ROOT)
@@ -134,7 +137,8 @@ class MaterialDialogButtons(private val scope: MaterialDialogScope) {
             },
             modifier = Modifier
                 .layoutId(MaterialDialogButtonTypes.Text)
-                .testTag(MaterialDialogButtonTypes.Text.testTag)
+                .testTag(MaterialDialogButtonTypes.Text.testTag),
+            colors = colors
         ) {
             Text(text = buttonText, style = textStyle)
         }
@@ -154,6 +158,7 @@ class MaterialDialogButtons(private val scope: MaterialDialogScope) {
         text: String? = null,
         textStyle: TextStyle = MaterialTheme.typography.button,
         @StringRes res: Int? = null,
+        colors: ButtonColors = ButtonDefaults.textButtonColors(),
         disableDismiss: Boolean = false,
         onClick: () -> Unit = {}
     ) {
@@ -175,7 +180,8 @@ class MaterialDialogButtons(private val scope: MaterialDialogScope) {
             },
             modifier = Modifier.layoutId(MaterialDialogButtonTypes.Positive)
                 .testTag(MaterialDialogButtonTypes.Positive.testTag),
-            enabled = buttonEnabled
+            enabled = buttonEnabled,
+            colors = colors
         ) {
             Text(text = buttonText, style = textStyle)
         }
@@ -194,6 +200,7 @@ class MaterialDialogButtons(private val scope: MaterialDialogScope) {
         text: String? = null,
         textStyle: TextStyle = MaterialTheme.typography.button,
         @StringRes res: Int? = null,
+        colors: ButtonColors = ButtonDefaults.textButtonColors(),
         onClick: () -> Unit = {}
     ) {
         val buttonText = getString(res, text).uppercase(Locale.ROOT)
@@ -207,7 +214,8 @@ class MaterialDialogButtons(private val scope: MaterialDialogScope) {
                 onClick()
             },
             modifier = Modifier.layoutId(MaterialDialogButtonTypes.Negative)
-                .testTag(MaterialDialogButtonTypes.Negative.testTag)
+                .testTag(MaterialDialogButtonTypes.Negative.testTag),
+            colors = colors
         ) {
             Text(text = buttonText, style = textStyle)
         }


### PR DESCRIPTION
# Description

Fix bug where an extra row is added on color chooser when the number of colors on list is even

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit and screenshot tests pass locally with my changes